### PR TITLE
More formal opcode definition

### DIFF
--- a/python_shader/_generator_base.py
+++ b/python_shader/_generator_base.py
@@ -164,7 +164,7 @@ class BaseSpirVGenerator:
     """ Base class that can be used by compiler implementations in the
     last compile step to generate the SpirV code. It has an internal
     representation of SpirV module and provides an API to generate
-    instructions.
+    instructions. This class it not aware of our bytecode representation.
     """
 
     def convert(self, input):

--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -6,7 +6,7 @@ from ._generator_base import BaseSpirVGenerator, ValueId, VariableAccessId
 from . import _spirv_constants as cc
 from . import _types
 
-# from . import opcodes as op
+from .opcodes import ByteCodeDefinitions
 
 # todo: build in some checks
 # - expect no func or entrypoint inside a func definition
@@ -14,7 +14,7 @@ from . import _types
 # - expect input/output/uniform at the very start (or inside an entrypoint?)
 
 
-class Bytecode2SpirVGenerator(BaseSpirVGenerator):
+class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
     """ A generator that operates on our own well-defined bytecode.
 
     Bytecode describing a stack machine is a pretty nice representation to generate
@@ -41,22 +41,14 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
 
         # Parse
         for opcode, *args in bytecode:
-            method_name = "_op_" + opcode[3:].lower()
-            method = getattr(self, method_name, None)
+            method = getattr(self, opcode.lower(), None)
             if method is None:
                 # pprint_bytecode(self._co)
-                raise RuntimeError(f"Cannot parse {opcode} yet (no {method_name}()).")
+                raise RuntimeError(f"Cannot parse {opcode} yet.")
             else:
                 method(*args)
 
-    def _op_pop_top(self):
-        self._stack.pop()
-
-    def _op_func(self, *args):
-        # Start function definition
-        raise NotImplementedError()
-
-    def _op_entrypoint(self, name, execution_model, execution_modes):
+    def co_entrypoint(self, name, execution_model, execution_modes):
         # Special function definition that acts as an entrypoint
 
         # Get execution_model flag
@@ -110,26 +102,49 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
         )
         self.gen_func_instruction(cc.OpLabel, self.obtain_id("label"))
 
-    def _op_func_end(self):
+    def co_func_end(self):
         # End function or entrypoint
         self.gen_func_instruction(cc.OpReturn)
         self.gen_func_instruction(cc.OpFunctionEnd)
 
-    def _op_input(self, location, *name_type_pairs):
-        self._setup_io_variable("input", location, name_type_pairs)
+    def co_call(self, nargs):
 
-    def _op_output(self, location, *name_type_pairs):
-        self._setup_io_variable("output", location, name_type_pairs)
+        args = self._stack[-nargs:]
+        self._stack[-nargs:] = []
+        func = self._stack.pop()
 
-    def _op_uniform(self, binding, *name_type_pairs):
-        self._setup_io_variable("uniform", binding, name_type_pairs)
+        if isinstance(func, type):
+            assert not func.is_abstract
+            if issubclass(func, _types.Vector):
+                result = self._vector_packing(func, args)
+            elif issubclass(func, _types.Array):
+                result = self._array_packing(args)
+            elif issubclass(func, _types.Scalar):
+                if len(args) != 1:
+                    raise TypeError("Scalar convert needs exactly one argument.")
+                result = self._convert_scalar(func, args[0])
+            self._stack.append(result)
+        else:
+            raise NotImplementedError()
 
-    def _op_buffer(self, binding, *name_type_pairs):
-        self._setup_io_variable("buffer", binding, name_type_pairs)
+    # %% IO
 
-    def _setup_io_variable(self, kind, location, name_type_pairs):
 
-        n_names = len(name_type_pairs) / 2
+    def co_input(self, location, name_type_items):
+        self._setup_io_variable("input", location, name_type_items)
+
+    def co_output(self, location, name_type_items):
+        self._setup_io_variable("output", location, name_type_items)
+
+    def co_uniform(self, binding, name_type_items):
+        self._setup_io_variable("uniform", binding, name_type_items)
+
+    def co_buffer(self, binding, name_type_items):
+        self._setup_io_variable("buffer", binding, name_type_items)
+
+    def _setup_io_variable(self, kind, location, name_type_items):
+
+        n_names = len(name_type_items)
         singleton_mode = n_names == 1 and kind in ("input", "output")
 
         # Triage over input kind
@@ -152,7 +167,7 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
         # Get the root variable
         if singleton_mode:
             # Singleton (not allowed for Uniform)
-            name, var_type = name_type_pairs
+            name, var_type = list(name_type_items.items())[0]
             var_name = "var-" + name
             # todo: should our bytecode be fully jsonable? or do we force actual types here?
             if isinstance(var_type, str):
@@ -166,8 +181,7 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
             ), f"euhm, I dont know if you can use block {kind}s"
             # Block - the variable is a struct
             subtypes = {}
-            for i in range(0, len(name_type_pairs), 2):
-                key, subtype = name_type_pairs[i], name_type_pairs[i + 1]
+            for key, subtype in name_type_items.items():
                 if isinstance(subtype, str):
                     subtypes[key] = _types.type_from_name(subtype)
                 else:
@@ -228,7 +242,12 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
                     raise NameError(f"{kind} {subname} already exists")
                 iodict[subname] = var_access.index(index_id, i)
 
-    def _op_load(self, name):
+    # %% Basics
+
+    def co_pop_top(self):
+        self._stack.pop()
+
+    def co_load_local(self, name):
         # store a variable that is used in an inner scope.
         if name in self._aliases:
             ob = self._aliases[name]
@@ -250,15 +269,7 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
             raise NameError(f"Using invalid variable: {name}")
         self._stack.append(ob)
 
-    def _op_load_constant(self, value):
-        id = self.obtain_constant(value)
-        self._stack.append(id)
-        # Also see OpConstantNull OpConstantSampler OpConstantComposite
-
-    def _op_load_global(self):
-        raise NotImplementedError()
-
-    def _op_store(self, name):
+    def co_store_local(self, name):
         ob = self._stack.pop()
         if name in self._output:
             ac = self._output[name]
@@ -273,32 +284,143 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
 
         self._aliases[name] = ob
 
-    def _op_call(self, nargs):
+    def co_load_index(self):
+        index = self._stack.pop()
+        container = self._stack.pop()
 
-        args = self._stack[-nargs:]
-        self._stack[-nargs:] = []
-        func = self._stack.pop()
+        # Get type of object and index
+        element_type = container.type.subtype
+        # assert index.type is int
 
-        if isinstance(func, type):
-            assert not func.is_abstract
-            if issubclass(func, _types.Vector):
-                result = self._vector_packing(func, args)
-            elif issubclass(func, _types.Array):
-                result = self._array_packing(args)
-            elif issubclass(func, _types.Scalar):
-                if len(args) != 1:
-                    raise TypeError("Scalar convert needs exactly one argument.")
-                result = self._convert_scalar(func, args[0])
-            self._stack.append(result)
+        if isinstance(container, VariableAccessId):
+            result_id = container.index(index)
+
+        elif issubclass(container.type, _types.Array):
+
+            # todo: maybe ... the variable for a constant should be created only once ... instead of every time it gets indexed
+            # Put the array into a variable
+            var_access = self.obtain_variable(container.type, cc.StorageClass_Function)
+            container_variable = var_access.variable
+            var_access.resolve_store(self, container.id)
+
+            # Prepare result id and type
+            result_id, result_type_id = self.obtain_value(element_type)
+
+            # Create pointer into the array
+            pointer1 = self.obtain_id("pointer")
+            pointer2 = self.obtain_id("pointer")
+            self.gen_instruction(
+                "types",
+                cc.OpTypePointer,
+                pointer1,
+                cc.StorageClass_Function,
+                result_type_id,
+            )
+            self.gen_func_instruction(
+                cc.OpInBoundsAccessChain, pointer1, pointer2, container_variable, index
+            )
+
+            # Load the element from the array
+            self.gen_func_instruction(cc.OpLoad, result_type_id, result_id, pointer2)
         else:
             raise NotImplementedError()
 
-    def _op_build_array(self, nargs):
+        self._stack.append(result_id)
+
+        # OpVectorExtractDynamic: Extract a single, dynamically selected, component of a vector.
+        # OpVectorInsertDynamic: Make a copy of a vector, with a single, variably selected, component modified.
+        # OpVectorShuffle: Select arbitrary components from two vectors to make a new vector.
+        # OpCompositeInsert: Make a copy of a composite object, while modifying one part of it. (updating an element)
+
+    def co_store_index(self):
+        index = self._stack.pop()
+        ob = self._stack.pop()
+        val = self._stack.pop()  # noqa
+
+        if isinstance(ob, VariableAccessId):
+            # Create new variable access for this last indexing op
+            ac = ob.index(index)
+            assert val.type is ac.type
+            # Then resolve the chain to a store op
+            ac.resolve_store(self, val)
+        else:
+            raise NotImplementedError()
+
+    def co_load_constant(self, value):
+        id = self.obtain_constant(value)
+        self._stack.append(id)
+        # Also see OpConstantNull OpConstantSampler OpConstantComposite
+
+    def co_load_array(self, nargs):
         # Literal array
         args = self._stack[-nargs:]
         self._stack[-nargs:] = []
         result = self._array_packing(args)
         self._stack.append(result)
+
+    # %% Math and more
+
+    def co_binary_op(self, operator):
+        assert False, "doet nie toch?"
+        right = self._stack.pop()
+        left = self._stack.pop()
+
+        assert left.type is _types.vec3
+        assert issubclass(right.type, _types.Float)
+
+        if operator == "*":
+            id, type_id = self.obtain_value(left.type)
+            self.gen_func_instruction(cc.OpVectorTimesScalar, type_id, id, left, right)
+        elif operator == "/":
+            1 / 0
+        elif operator == "+":
+            1 / 0
+        elif operator == "-":
+            1 / 0
+        else:
+            raise NotImplementedError(f"Wut is {operator}??")
+        self._stack.append(id)
+
+    def co_add(self):
+        self._binary_math_op("add")
+
+    def co_sub(self):
+        self._binary_math_op("subtract")
+
+    def co_mul(self):
+        self._binary_math_op("multiply")
+
+    def co_div(self):
+        self._binary_math_op("divide")
+
+    def _binary_math_op(self, action):
+        val2 = self._stack.pop()
+        val1 = self._stack.pop()
+
+        if val1.type is not val2.type:
+            raise TypeError(
+                f"Cannot {action} values of different types ({val1.type} and {val2.type})"
+            )
+        result_id, type_id = self.obtain_value(val1.type)
+
+        if issubclass(val1.type, _types.Float):
+            M = {
+                "add": cc.OpFAdd,
+                "subtract": cc.OpFSub,
+                "multiply": cc.OpFMul,
+                "divide": cc.OpFDiv,
+            }
+            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
+        elif issubclass(val1.type, _types.Int):
+            M = {"add": cc.OpIAdd, "subtract": cc.OpISub, "multiply": cc.OpIMul}
+            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
+        else:
+            raise TypeError(f"Cannot {action} values of type {val1.type}.")
+
+        self._stack.append(result_id)
+
+
+    # %% Helper methods
 
     def _convert_scalar(self, out_type, arg):
         return self._convert_scalar_or_vector(out_type, out_type, arg, arg.type)
@@ -454,128 +576,3 @@ class Bytecode2SpirVGenerator(BaseSpirVGenerator):
         # todo: or OpConstantComposite
 
         return result_id
-
-    def _op_binary_op(self, operator):
-        right = self._stack.pop()
-        left = self._stack.pop()
-
-        assert left.type is _types.vec3
-        assert issubclass(right.type, _types.Float)
-
-        if operator == "*":
-            id, type_id = self.obtain_value(left.type)
-            self.gen_func_instruction(cc.OpVectorTimesScalar, type_id, id, left, right)
-        elif operator == "/":
-            1 / 0
-        elif operator == "+":
-            1 / 0
-        elif operator == "-":
-            1 / 0
-        else:
-            raise NotImplementedError(f"Wut is {operator}??")
-        self._stack.append(id)
-
-    def _op_index(self, n):
-        assert n == 1
-        index = self._stack.pop()
-        container = self._stack.pop()
-
-        # Get type of object and index
-        element_type = container.type.subtype
-        # assert index.type is int
-
-        if isinstance(container, VariableAccessId):
-            result_id = container.index(index)
-
-        elif issubclass(container.type, _types.Array):
-
-            # todo: maybe ... the variable for a constant should be created only once ... instead of every time it gets indexed
-            # Put the array into a variable
-            var_access = self.obtain_variable(container.type, cc.StorageClass_Function)
-            container_variable = var_access.variable
-            var_access.resolve_store(self, container.id)
-
-            # Prepare result id and type
-            result_id, result_type_id = self.obtain_value(element_type)
-
-            # Create pointer into the array
-            pointer1 = self.obtain_id("pointer")
-            pointer2 = self.obtain_id("pointer")
-            self.gen_instruction(
-                "types",
-                cc.OpTypePointer,
-                pointer1,
-                cc.StorageClass_Function,
-                result_type_id,
-            )
-            self.gen_func_instruction(
-                cc.OpInBoundsAccessChain, pointer1, pointer2, container_variable, index
-            )
-
-            # Load the element from the array
-            self.gen_func_instruction(cc.OpLoad, result_type_id, result_id, pointer2)
-        else:
-            raise NotImplementedError()
-
-        self._stack.append(result_id)
-
-        # OpVectorExtractDynamic: Extract a single, dynamically selected, component of a vector.
-        # OpVectorInsertDynamic: Make a copy of a vector, with a single, variably selected, component modified.
-        # OpVectorShuffle: Select arbitrary components from two vectors to make a new vector.
-        # OpCompositeInsert: Make a copy of a composite object, while modifying one part of it. (updating an element)
-
-    def _op_index_set(self):
-        index = self._stack.pop()
-        ob = self._stack.pop()
-        val = self._stack.pop()  # noqa
-
-        if isinstance(ob, VariableAccessId):
-            # Create new variable access for this last indexing op
-            ac = ob.index(index)
-            assert val.type is ac.type
-            # Then resolve the chain to a store op
-            ac.resolve_store(self, val)
-        else:
-            raise NotImplementedError()
-
-    def _op_if(self):
-        raise NotImplementedError()
-        # OpSelect
-
-    def _op_add(self):
-        self._binary_math_op("add")
-
-    def _op_sub(self):
-        self._binary_math_op("subtract")
-
-    def _op_mul(self):
-        self._binary_math_op("multiply")
-
-    def _op_div(self):
-        self._binary_math_op("divide")
-
-    def _binary_math_op(self, action):
-        val2 = self._stack.pop()
-        val1 = self._stack.pop()
-
-        if val1.type is not val2.type:
-            raise TypeError(
-                f"Cannot {action} values of different types ({val1.type} and {val2.type})"
-            )
-        result_id, type_id = self.obtain_value(val1.type)
-
-        if issubclass(val1.type, _types.Float):
-            M = {
-                "add": cc.OpFAdd,
-                "subtract": cc.OpFSub,
-                "multiply": cc.OpFMul,
-                "divide": cc.OpFDiv,
-            }
-            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
-        elif issubclass(val1.type, _types.Int):
-            M = {"add": cc.OpIAdd, "subtract": cc.OpISub, "multiply": cc.OpIMul}
-            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
-        else:
-            raise TypeError(f"Cannot {action} values of type {val1.type}.")
-
-        self._stack.append(result_id)

--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -129,7 +129,6 @@ class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
 
     # %% IO
 
-
     def co_input(self, location, name_type_items):
         self._setup_io_variable("input", location, name_type_items)
 
@@ -418,7 +417,6 @@ class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
             raise TypeError(f"Cannot {action} values of type {val1.type}.")
 
         self._stack.append(result_id)
-
 
     # %% Helper methods
 

--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -359,62 +359,30 @@ class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
 
     # %% Math and more
 
-    def co_binary_op(self, operator):
-        assert False, "doet nie toch?"
-        right = self._stack.pop()
-        left = self._stack.pop()
+    def co_binop(self, operator):
 
-        assert left.type is _types.vec3
-        assert issubclass(right.type, _types.Float)
-
-        if operator == "*":
-            id, type_id = self.obtain_value(left.type)
-            self.gen_func_instruction(cc.OpVectorTimesScalar, type_id, id, left, right)
-        elif operator == "/":
-            1 / 0
-        elif operator == "+":
-            1 / 0
-        elif operator == "-":
-            1 / 0
-        else:
-            raise NotImplementedError(f"Wut is {operator}??")
-        self._stack.append(id)
-
-    def co_add(self):
-        self._binary_math_op("add")
-
-    def co_sub(self):
-        self._binary_math_op("subtract")
-
-    def co_mul(self):
-        self._binary_math_op("multiply")
-
-    def co_div(self):
-        self._binary_math_op("divide")
-
-    def _binary_math_op(self, action):
         val2 = self._stack.pop()
         val1 = self._stack.pop()
 
         if val1.type is not val2.type:
             raise TypeError(
-                f"Cannot {action} values of different types ({val1.type} and {val2.type})"
+                f"Cannot {operator} values of different types ({val1.type} and {val2.type})"
             )
         result_id, type_id = self.obtain_value(val1.type)
 
         if issubclass(val1.type, _types.Float):
             M = {
                 "add": cc.OpFAdd,
-                "subtract": cc.OpFSub,
-                "multiply": cc.OpFMul,
-                "divide": cc.OpFDiv,
+                "sub": cc.OpFSub,
+                "mul": cc.OpFMul,
+                "div": cc.OpFDiv,
             }
-            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
+            self.gen_func_instruction(M[operator], type_id, result_id, val1, val2)
         elif issubclass(val1.type, _types.Int):
             M = {"add": cc.OpIAdd, "subtract": cc.OpISub, "multiply": cc.OpIMul}
-            self.gen_func_instruction(M[action], type_id, result_id, val1, val2)
+            self.gen_func_instruction(M[operator], type_id, result_id, val1, val2)
         else:
-            raise TypeError(f"Cannot {action} values of type {val1.type}.")
+            raise TypeError(f"Cannot {operator} values of type {val1.type}.")
 
         self._stack.append(result_id)
 

--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -6,7 +6,7 @@ from ._generator_base import BaseSpirVGenerator, ValueId, VariableAccessId
 from . import _spirv_constants as cc
 from . import _types
 
-from .opcodes import ByteCodeDefinitions
+from .opcodes import OpCodeDefinitions
 
 # todo: build in some checks
 # - expect no func or entrypoint inside a func definition
@@ -14,7 +14,7 @@ from .opcodes import ByteCodeDefinitions
 # - expect input/output/uniform at the very start (or inside an entrypoint?)
 
 
-class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
+class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
     """ A generator that operates on our own well-defined bytecode.
 
     Bytecode describing a stack machine is a pretty nice representation to generate
@@ -246,7 +246,7 @@ class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
     def co_pop_top(self):
         self._stack.pop()
 
-    def co_load_local(self, name):
+    def co_load_name(self, name):
         # store a variable that is used in an inner scope.
         if name in self._aliases:
             ob = self._aliases[name]
@@ -268,7 +268,7 @@ class Bytecode2SpirVGenerator(ByteCodeDefinitions, BaseSpirVGenerator):
             raise NameError(f"Using invalid variable: {name}")
         self._stack.append(ob)
 
-    def co_store_local(self, name):
+    def co_store_name(self, name):
         ob = self._stack.pop()
         if name in self._output:
             ac = self._output[name]

--- a/python_shader/opcodes.py
+++ b/python_shader/opcodes.py
@@ -20,25 +20,129 @@ def str2bc(s):
     return opcodes
 
 
-CO_FUNC = "CO_FUNC"
-CO_ENTRYPOINT = "CO_ENTRYPOINT"
-CO_FUNC_END = "CO_FUNC_END"
-CO_INPUT = "CO_INPUT"
-CO_OUTPUT = "CO_OUTPUT"
-CO_SET_OUTPUT = "CO_SET_OUTPUT"  # todo :.....
-CO_UNIFORM = "CO_UNIFORM"
-CO_BUFFER = "CO_BUFFER"
-CO_ASSIGN = "CO_ASSIGN"
-CO_LOAD_CONSTANT = "CO_LOAD_CONSTANT"
-CO_LOAD = "CO_LOAD"
-CO_BINARY_OP = "CO_BINARY_OP"
-CO_STORE = "CO_STORE"
-CO_CALL = "CO_CALL"
-CO_INDEX = "CO_INDEX"  # INDEX_GET
-CO_INDEX_SET = "CO_INDEX_SET"
-CO_POP_TOP = "CO_POP_TOP"
-CO_BUILD_ARRAY = "CO_BUILD_ARRAY"
-CO_ADD = "CO_ADD"
-CO_SUB = "CO_SUB"
-CO_MUL = "CO_MUL"
-CO_DIV = "CO_DIV"
+class ByteCodeDefinitions:
+    """ Abstract class that defines the bytecode ops as methods, making
+    it easy to document them (using docstring and arguments.
+
+    Code that produces bytecode can use this as class as a kind of enum
+    for the opcodes (and for documentation). Code that consumes bytecode
+    can subclass this class and implement the methods.
+    """
+
+    # %% High level stuff
+
+    def co_func(self, name):
+        """ Define a function. WIP
+        """
+        raise NotImplementedError()
+
+    def co_entrypoint(self, name, shader_type, execution_modes):
+        """ Define the start of an entry point function.
+        * name (str): The function name.
+        * shader_type (str): 'vertex', 'fragment' or 'compute'.
+        * execution_modes (dict): a dict with execution modes.
+        """
+        raise NotImplementedError()
+
+    def co_func_end(self):
+        """ Define the end of a function (or entry point).
+        """
+        raise NotImplementedError()
+
+    def co_call(self, nargs):
+        """ Call a function. WIP
+        """
+        raise NotImplementedError()
+
+
+    # %% IO
+
+    def co_input(self, location, name_type_items):
+        """ Define shader input.
+        """
+        raise NotImplementedError()
+
+    def co_output(self, location, name_type_items):
+        """ Define sader output.
+        """
+        raise NotImplementedError()
+
+    def co_uniform(self, location, name_type_items):
+        """ Define shader uniform.
+        """
+        raise NotImplementedError()
+
+    def co_buffer(self, location, name_type_items):
+        """ Define storage buffer.
+        """
+        raise NotImplementedError()
+
+    # %% Basics
+
+    def co_pop_top(self):
+        """ Pop the top of the stack.
+        """
+        raise NotImplementedError()
+
+    # todo: local is not the right name, since we use it for globals and io too
+    def co_load_local(self, varname):
+        """ Load a local variable onto the stack.
+        """
+        raise NotImplementedError()
+
+    def co_store_local(self, varname):
+        """ Store the TOS under the given name, so it can be referenced later
+        using co_load_local.
+        """
+        raise NotImplementedError()
+
+    def co_load_index(self):
+        """ Implements TOS = TOS1[TOS].
+        """
+        raise NotImplementedError()
+
+    def co_store_index(self):
+        """ Implements TOS1[TOS] = TOS2.
+        """
+        raise NotImplementedError()
+
+    def co_load_constant(self, value):
+        """ Load a constant value onto the stack.
+        The value can be a float, int, bool. Tuple for vec?
+        """
+        raise NotImplementedError()
+
+    def co_load_array(self, nargs):
+        """ Build an array composed of the nargs last elements on the stack,
+        and push that on the stack.
+        """
+        raise NotImplementedError()
+
+    # %% Math and more
+
+    def co_binop(self, op):
+        """ Implements TOS = TOS1 ?? TOS, where ?? is the given operation,
+        which can be: add, sub, mul, div, ...
+        """
+        raise NotImplementedError()
+        # todo: use a generic binop or one op for each op?
+
+    def co_add(self):
+        """ Implements TOS = TOS1 + TOS.
+        """
+        raise NotImplementedError()
+
+    def co_sub(self):
+        """ Implements TOS = TOS1 - TOS.
+        """
+        raise NotImplementedError()
+
+    def co_mul(self):
+        """ Implements TOS = TOS1 * TOS.
+        """
+        raise NotImplementedError()
+
+    def co_div(self):
+        """ Implements TOS = TOS1 / TOS. Float types only.
+        """
+        raise NotImplementedError()

--- a/python_shader/opcodes.py
+++ b/python_shader/opcodes.py
@@ -134,24 +134,3 @@ class OpCodeDefinitions:
         which can be: add, sub, mul, div, ...
         """
         raise NotImplementedError()
-        # todo: use a generic binop or one op for each op?
-
-    def co_add(self):
-        """ Implements TOS = TOS1 + TOS.
-        """
-        raise NotImplementedError()
-
-    def co_sub(self):
-        """ Implements TOS = TOS1 - TOS.
-        """
-        raise NotImplementedError()
-
-    def co_mul(self):
-        """ Implements TOS = TOS1 * TOS.
-        """
-        raise NotImplementedError()
-
-    def co_div(self):
-        """ Implements TOS = TOS1 / TOS. Float types only.
-        """
-        raise NotImplementedError()

--- a/python_shader/opcodes.py
+++ b/python_shader/opcodes.py
@@ -54,7 +54,6 @@ class ByteCodeDefinitions:
         """
         raise NotImplementedError()
 
-
     # %% IO
 
     def co_input(self, location, name_type_items):

--- a/python_shader/opcodes.py
+++ b/python_shader/opcodes.py
@@ -1,8 +1,17 @@
 """ The opcodes of our bytecode.
 
-We define our own little bytecode. It consists of a list of tuples, in
-which the first element is a (str) opcode, and the remaining elements
-its arguments. These opcodes are to be executed in a stack machine.
+Bytecode describing a stack machine is a pretty nice representation to
+generate SpirV code, because the code gets visited in a flow, making
+it relatively easy to do type inference.
+
+By defining our own bytecode, we can implement a single generator that
+consumes it, and use the bytecode as a target for different source
+languages. Also, we can target the bytecode towards SpirV, which helps
+keeping the generator relatively simple.
+
+Our bytecode consists of a list of tuples, in which the first element
+is a (str) opcode, and the remaining elements its arguments. These
+opcodes are to be executed in a stack machine.
 
 The term bytecode is a bit odd, because we never really store it as
 bytes. But the meaning of the term "bytecode" most closely represents
@@ -33,7 +42,7 @@ def str2bc(s):
 
 class OpCodeDefinitions:
     """ Abstract class that defines the bytecode ops as methods, making
-    it easy to document them (using docstring and arguments.
+    it easy to document them (using docstring and arguments).
 
     Code that produces bytecode can use this as class as a kind of enum
     for the opcodes (and for documentation). Code that consumes bytecode
@@ -94,12 +103,12 @@ class OpCodeDefinitions:
         """
         raise NotImplementedError()
 
-    def co_load_name(self, varname):
+    def co_load_name(self, name):
         """ Load a local variable onto the stack.
         """
         raise NotImplementedError()
 
-    def co_store_name(self, varname):
+    def co_store_name(self, name):
         """ Store the TOS under the given name, so it can be referenced later
         using co_load_name.
         """

--- a/python_shader/opcodes.py
+++ b/python_shader/opcodes.py
@@ -1,17 +1,28 @@
 """ The opcodes of our bytecode.
-"""
 
-# todo: the name is misleading. It's a stack machine representation, but it is never represented in bytes.
+We define our own little bytecode. It consists of a list of tuples, in
+which the first element is a (str) opcode, and the remaining elements
+its arguments. These opcodes are to be executed in a stack machine.
+
+The term bytecode is a bit odd, because we never really store it as
+bytes. But the meaning of the term "bytecode" most closely represents
+this intermediate representation of code.
+
+"""
 
 import json
 
 
 def bc2str(opcodes):
+    """ Serialize opcodes to str, one opcode + args per line (hint: it's json).
+    """
     lines = [json.dumps(op)[1:-1] for op in opcodes]
     return "\n".join(lines)
 
 
 def str2bc(s):
+    """ Get a list of opcodes (+args) from string.
+    """
     opcodes = []
     for line in s.splitlines():
         line = line.strip()
@@ -20,7 +31,7 @@ def str2bc(s):
     return opcodes
 
 
-class ByteCodeDefinitions:
+class OpCodeDefinitions:
     """ Abstract class that defines the bytecode ops as methods, making
     it easy to document them (using docstring and arguments.
 
@@ -83,15 +94,14 @@ class ByteCodeDefinitions:
         """
         raise NotImplementedError()
 
-    # todo: local is not the right name, since we use it for globals and io too
-    def co_load_local(self, varname):
+    def co_load_name(self, varname):
         """ Load a local variable onto the stack.
         """
         raise NotImplementedError()
 
-    def co_store_local(self, varname):
+    def co_store_name(self, varname):
         """ Store the TOS under the given name, so it can be referenced later
-        using co_load_local.
+        using co_load_name.
         """
         raise NotImplementedError()
 

--- a/python_shader/py.py
+++ b/python_shader/py.py
@@ -2,7 +2,7 @@ import inspect
 from dis import dis as pprint_bytecode
 
 from ._module import ShaderModule
-from . import opcodes as op
+from .opcodes import ByteCodeDefinitions as op
 from ._dis import dis
 from ._types import spirv_types_map
 
@@ -58,7 +58,7 @@ class PyBytecode2Bytecode:
 
         # todo: odd, but name must be the same for vertex and fragment shader??
         entrypoint_name = "main"  # py_func.__name__
-        self.emit(op.CO_ENTRYPOINT, entrypoint_name, shader_type, {})
+        self.emit(op.co_entrypoint, entrypoint_name, shader_type, {})
 
         # # Parse function inputs
         # todo: remove or revive? (was part of experimental IO syntax)
@@ -71,19 +71,25 @@ class PyBytecode2Bytecode:
         #     if isinstance(slot, str):
         #         # Builtin
         #         self._input[argname] = argtype
-        #         self.emit(op.CO_INPUT, slot, argname, argtype)
+        #         self.emit(op.co_input, slot, argname, argtype)
         #     elif isinstance(slot, int):
         #         # Attribute
         #         self._input[argname] = argtype
-        #         self.emit(op.CO_INPUT, slot, argname, argtype)
+        #         self.emit(op.co_input, slot, argname, argtype)
         #     else:
         #         # todo: how to specify a Buffer, Texture, Sampler?
         #         raise TypeError(f"Python-shader arg slot of {argname} must be int or str.")
 
         self._convert()
-        self.emit(op.CO_FUNC_END)
+        self.emit(op.co_func_end)
 
     def emit(self, opcode, *args):
+        if callable(opcode):
+            fcode = opcode.__code__
+            opcode = fcode.co_name  # a method of ByteCodeDefinitions class
+            argnames = [fcode.co_varnames[i] for i in range(fcode.co_argcount)][1:]
+            if len(args) != len(argnames):
+                raise RuntimeError(f"Got {len(args)} args for {opcode}({', '.join(argnames)})")
         self._opcodes.append((opcode, *args))
 
     def dump(self):
@@ -141,10 +147,10 @@ class PyBytecode2Bytecode:
 
     def _define(self, kind, name, location, type):
         COS = {
-            "input": op.CO_INPUT,
-            "output": op.CO_OUTPUT,
-            "uniform": op.CO_UNIFORM,
-            "buffer": op.CO_BUFFER,
+            "input": op.co_input,
+            "output": op.co_output,
+            "uniform": op.co_uniform,
+            "buffer": op.co_buffer,
         }
         DICTS = {
             "input": self._input,
@@ -153,18 +159,16 @@ class PyBytecode2Bytecode:
             "buffer": self._buffer,
         }
         co = COS[kind]
-        d = DICTS[kind]
-        args = [location]
-        args.extend([kind + "." + name, type])
-        d[name] = type
-        self.emit(co, *args)
+        name_type_items = {kind + "." + name: type}
+        DICTS[kind].update({name: type})
+        self.emit(co, location, name_type_items)
 
     # %%
 
     def _op_pop_top(self):
         self._stack.pop()
-        self._next()  # todo: why need pointer advance?
-        self.emit(op.CO_POP_TOP)
+        self._next()
+        self.emit(op.co_pop_top)
 
     def _op_return_value(self):
         result = self._stack.pop()
@@ -179,7 +183,7 @@ class PyBytecode2Bytecode:
         if name in ("input", "output", "uniform", "buffer"):
             self._stack.append(name)
         else:
-            self.emit(op.CO_LOAD, name)
+            self.emit(op.co_load_local, name)
             self._stack.append(name)  # todo: euhm, do we still need a stack?
 
     def _op_load_const(self):
@@ -189,7 +193,7 @@ class PyBytecode2Bytecode:
             # We use strings in e.g. input.define(), mmm
             self._stack.append(ob)
         elif isinstance(ob, (float, int, bool)):
-            self.emit(op.CO_LOAD_CONSTANT, ob)
+            self.emit(op.co_load_constant, ob)
             self._stack.append(ob)
         elif ob is None:
             self._stack.append(None)  # todo: for the final return ...
@@ -201,7 +205,7 @@ class PyBytecode2Bytecode:
     def _op_load_global(self):
         i = self._next()
         name = self._co.co_names[i]
-        self.emit(op.CO_LOAD, name)
+        self.emit(op.co_load_local, name)
         self._stack.append(name)
 
     def _op_load_attr(self):
@@ -214,17 +218,17 @@ class PyBytecode2Bytecode:
         elif ob == "input":
             if name not in self._input:
                 raise NameError(f"No input {name} defined.")
-            self.emit(op.CO_LOAD, "input." + name)
+            self.emit(op.co_load_local, "input." + name)
             self._stack.append("input." + name)
         elif ob == "uniform":
             if name not in self._uniform:
                 raise NameError(f"No uniform {name} defined.")
-            self.emit(op.CO_LOAD, "uniform." + name)
+            self.emit(op.co_load_local, "uniform." + name)
             self._stack.append("uniform." + name)
         elif ob == "buffer":
             if name not in self._buffer:
                 raise NameError(f"No buffer {name} defined.")
-            self.emit(op.CO_LOAD, "buffer." + name)
+            self.emit(op.co_load_local, "buffer." + name)
             self._stack.append("buffer." + name)
         elif ob == "output":
             raise AttributeError("Cannot read from output.")
@@ -245,11 +249,11 @@ class PyBytecode2Bytecode:
         elif ob == "buffer":
             if name not in self._buffer:
                 raise NameError(f"No buffer {name} defined.")
-            self.emit(op.CO_STORE, "buffer." + name)
+            self.emit(op.co_store_local, "buffer." + name)
         elif ob == "output":
             if name not in self._output:
                 raise NameError(f"No output {name} defined.")
-            self.emit(op.CO_STORE, "output." + name)
+            self.emit(op.co_store_local, "output." + name)
         else:
             raise NotImplementedError()
 
@@ -257,7 +261,7 @@ class PyBytecode2Bytecode:
         i = self._next()
         name = self._co.co_varnames[i]
         ob = self._stack.pop()  # noqa - ob not used
-        self.emit(op.CO_STORE, name)
+        self.emit(op.co_store_local, name)
 
     def _op_load_method(self):  # new in Python 3.7
         i = self._next()
@@ -285,7 +289,7 @@ class PyBytecode2Bytecode:
             result = func(ob, name, location, type)
             self._stack.append(result)
         else:
-            self.emit(op.CO_CALL, nargs)
+            self.emit(op.co_call, nargs)
             self._stack.append(None)
 
     def _op_call_function_kw(self):
@@ -328,7 +332,7 @@ class PyBytecode2Bytecode:
         else:
             # Normal call
             assert isinstance(func, str)
-            self.emit(op.CO_CALL, nargs)
+            self.emit(op.co_call, nargs)
             self._stack.append(None)
 
     def _op_binary_subscr(self):
@@ -336,9 +340,9 @@ class PyBytecode2Bytecode:
         index = self._stack.pop()
         ob = self._stack.pop()  # noqa - ob not ised
         if isinstance(index, tuple):
-            self.emit(op.CO_INDEX, len(index))
+            self.emit(op.co_load_index, len(index))
         else:
-            self.emit(op.CO_INDEX, 1)
+            self.emit(op.co_load_index)
         self._stack.append(None)
 
     def _op_store_subscr(self):
@@ -346,7 +350,7 @@ class PyBytecode2Bytecode:
         index = self._stack.pop()  # noqa
         ob = self._stack.pop()  # noqa
         val = self._stack.pop()  # noqa
-        self.emit(op.CO_INDEX_SET)
+        self.emit(op.co_store_index)
 
     def _op_build_tuple(self):
         # todo: but I want to be able to do ``x, y = y, x`` !
@@ -367,7 +371,7 @@ class PyBytecode2Bytecode:
         res = [self._stack.pop() for i in range(n)]
         res = list(reversed(res))
         self._stack.append(res)
-        self.emit(op.CO_BUILD_ARRAY, n)
+        self.emit(op.co_load_array, n)
 
     def _op_build_map(self):
         raise SyntaxError("Dict not allowed in Shader-Python")
@@ -399,25 +403,25 @@ class PyBytecode2Bytecode:
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.CO_ADD)
+        self.emit(op.co_add)
 
     def _op_binary_subtract(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.CO_SUB)
+        self.emit(op.co_sub)
 
     def _op_binary_multiply(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.CO_MUL)
+        self.emit(op.co_mul)
 
     def _op_binary_true_divide(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.CO_DIV)
+        self.emit(op.co_div)

--- a/python_shader/py.py
+++ b/python_shader/py.py
@@ -405,25 +405,25 @@ class PyBytecode2Bytecode:
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.co_add)
+        self.emit(op.co_binop, "add")
 
     def _op_binary_subtract(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.co_sub)
+        self.emit(op.co_binop, "sub")
 
     def _op_binary_multiply(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.co_mul)
+        self.emit(op.co_binop, "mul")
 
     def _op_binary_true_divide(self):
         self._next()
         self._stack.pop()
         self._stack.pop()
         self._stack.append(None)
-        self.emit(op.co_div)
+        self.emit(op.co_binop, "div")

--- a/python_shader/py.py
+++ b/python_shader/py.py
@@ -89,7 +89,9 @@ class PyBytecode2Bytecode:
             opcode = fcode.co_name  # a method of ByteCodeDefinitions class
             argnames = [fcode.co_varnames[i] for i in range(fcode.co_argcount)][1:]
             if len(args) != len(argnames):
-                raise RuntimeError(f"Got {len(args)} args for {opcode}({', '.join(argnames)})")
+                raise RuntimeError(
+                    f"Got {len(args)} args for {opcode}({', '.join(argnames)})"
+                )
         self._opcodes.append((opcode, *args))
 
     def dump(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,3 +37,34 @@ def test_spirv_constants():
     assert isinstance(repr(cc.Version), str)
     assert int(cc.Version) == cc.Version
     # assert str(int(cc.Version)) == str(cc.Version)  # not on Python 3.8 :)
+
+
+def test_that_bytecode_generator_matches_opcode_definitions():
+    cls1 = python_shader.opcodes.OpCodeDefinitions
+    cls2 = python_shader._generator_bc.Bytecode2SpirVGenerator
+    count = 0
+
+    for name, func1 in cls1.__dict__.items():
+        if not name.startswith("co_"):
+            continue
+        count += 1
+
+        assert name in cls2.__dict__, f"{name} not implemented"
+        func2 = cls2.__dict__[name]
+
+        fcode1 = func1.__code__
+        fcode2 = func2.__code__
+        argnames1 = [fcode1.co_varnames[i] for i in range(fcode1.co_argcount)][1:]
+        argnames2 = [fcode2.co_varnames[i] for i in range(fcode2.co_argcount)][1:]
+        print(name)
+        assert argnames1 == argnames2
+
+    for name, func2 in cls2.__dict__.items():
+        if not name.startswith("co_"):
+            continue
+        assert name in cls1.__dict__, f"{name} is not a known opcode"
+
+    assert count > 12  # Just make sure we're not skipping all
+
+
+test_that_bytecode_generator_matches_opcode_definitions()

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -82,10 +82,10 @@ def python2shader_and_validate(func):
 
 
 HASHES = {
-    "test_null_shader.vertex_shader": ("801b48feb24d7aea", "a48ffae9d0f09a5c"),
-    "test_triangle_shader.vertex_shader": ("9cdef2b9fc3befa3", "b886a8bb3c375e81"),
-    "test_triangle_shader.fragment_shader": ("02bcc64a3e8b05d3", "7bd19fb630a787ce"),
-    "test_compute_shader.compute_shader": ("02822d1f23bee04d", "b31b56f93d83e6e6"),
+    "test_null_shader.vertex_shader": ("bc099a07b86d70f2", "a48ffae9d0f09a5c"),
+    "test_triangle_shader.vertex_shader": ("671577253fa75b41", "b886a8bb3c375e81"),
+    "test_triangle_shader.fragment_shader": ("982f5530ea253ca4", "7bd19fb630a787ce"),
+    "test_compute_shader.compute_shader": ("3bf7aea392bbe4fb", "b31b56f93d83e6e6"),
 }
 
 

--- a/tests/test_py_cast.py
+++ b/tests/test_py_cast.py
@@ -234,17 +234,17 @@ def skip_if_no_wgpu():
 
 
 HASHES = {
-    "test_cast_i32_f32.compute_shader": ("60408a1ad7fe1e52", "3914e7dbbb8738a3"),
-    "test_cast_u8_f32.compute_shader": ("7b9a513e3d139327", "e3d7a1a541c4dfae"),
-    "test_cast_f32_i32.compute_shader": ("4e506c8a9685bb1d", "35064513c21443a2"),
-    "test_cast_f32_f32.compute_shader": ("41ec80be0c5fbd4a", "5c359370f12aaf05"),
-    "test_cast_f32_f64.compute_shader": ("02b0ba02f800c7e7", "5689829983c94b14"),
-    "test_cast_i64_i16.compute_shader": ("6553d81543636c57", "fcf2872482050bfb"),
-    "test_cast_i16_u8.compute_shader": ("b31e9fa73f7c4b79", "81ea5397bbfd7c86"),
-    "test_cast_vec_ivec2_vec2.compute_shader": ("beedd6250b36bb4a", "0eeb980b0658a970"),
-    "test_cast_vec_any_vec4.compute_shader": ("c81e2174c6809e11", "7a99f4902cfad233"),
-    "test_cast_vec_ivec3_vec3.compute_shader": ("753c1dad6243f826", "376fffdc9d560eb5"),
-    "test_cast_ivec2_bvec2.compute_shader": ("9f86931c58e7d7a0", "3155595307fbc43a"),
+    "test_cast_i32_f32.compute_shader": ("d706594ebae7e631", "3914e7dbbb8738a3"),
+    "test_cast_u8_f32.compute_shader": ("7dc48f8105ca9a4f", "e3d7a1a541c4dfae"),
+    "test_cast_f32_i32.compute_shader": ("d4d7bdea8afce48b", "35064513c21443a2"),
+    "test_cast_f32_f32.compute_shader": ("eb95481dde049870", "5c359370f12aaf05"),
+    "test_cast_f32_f64.compute_shader": ("ef2254814ec474b8", "5689829983c94b14"),
+    "test_cast_i64_i16.compute_shader": ("bd23f3fc85748fdb", "fcf2872482050bfb"),
+    "test_cast_i16_u8.compute_shader": ("1e9f81eb17b89e9a", "81ea5397bbfd7c86"),
+    "test_cast_vec_ivec2_vec2.compute_shader": ("d45b2f3931b26a71", "0eeb980b0658a970"),
+    "test_cast_vec_any_vec4.compute_shader": ("8c198d2037dedd28", "7a99f4902cfad233"),
+    "test_cast_vec_ivec3_vec3.compute_shader": ("ced1656635fab68b", "376fffdc9d560eb5"),
+    "test_cast_ivec2_bvec2.compute_shader": ("dfa6a74dd68aee89", "3155595307fbc43a"),
 }
 
 if __name__ == "__main__":

--- a/tests/test_py_compute.py
+++ b/tests/test_py_compute.py
@@ -66,8 +66,8 @@ def skip_if_no_wgpu():
 
 
 HASHES = {
-    "test_index.compute_shader": ("344f1e42e6addbf2", "dea9d31b63653ae6"),
-    "test_copy.compute_shader": ("02822d1f23bee04d", "b31b56f93d83e6e6"),
+    "test_index.compute_shader": ("66a2c50d263da09d", "dea9d31b63653ae6"),
+    "test_copy.compute_shader": ("3bf7aea392bbe4fb", "b31b56f93d83e6e6"),
 }
 
 

--- a/tests/test_py_math.py
+++ b/tests/test_py_math.py
@@ -77,8 +77,8 @@ def skip_if_no_wgpu():
 
 
 HASHES = {
-    "test_add_sub.compute_shader": ("24c21a8d73285a73", "7f7086502987b69d"),
-    "test_mul_div.compute_shader": ("98edd5248c516ec7", "4b2bfc04122681ca"),
+    "test_add_sub.compute_shader": ("b086a41ca5ebb7ae", "7f7086502987b69d"),
+    "test_mul_div.compute_shader": ("b1dce5b5c141ecf1", "4b2bfc04122681ca"),
 }
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -88,11 +88,14 @@ def run_test_and_print_new_hashes(ns):
     else:
         n_more = len(set(new_hashes).difference(old_hashes))
         n_less = len(set(old_hashes).difference(new_hashes))
-        n_diff = sum(
-            new_hashes[key] != old_hashes[key]
-            for key in set(old_hashes).intersection(new_hashes)
+        keys_in_both = set(old_hashes).intersection(new_hashes)
+        n_diff = sum(new_hashes[key] != old_hashes[key] for key in keys_in_both)
+        n_diff1 = sum(new_hashes[key][0] != old_hashes[key][0] for key in keys_in_both)
+        n_diff2 = sum(new_hashes[key][1] != old_hashes[key][1] for key in keys_in_both)
+        print(
+            f"Hashes changed: {n_more} added, {n_less} removed, "
+            f"{n_diff1}/{n_diff2}/{n_diff} changed."
         )
-        print(f"Hashes changed: {n_more} added, {n_less} removed, {n_diff} changed.")
 
 
 def _determine_can_use_vulkan_sdk():


### PR DESCRIPTION
The opcodes of our own bytecode representation is now defined as methods on a class, so that the args of each opcode are documented and can be checked, and a docstring can be attached. Can also generate docs from this later.

Also refactored some of the opcodes a bit. Worth noting that the hashes for the spirv code of all tests are not changed :)