### PR TITLE
Adjust to new wgpu API

### DIFF
--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -114,8 +114,7 @@ def _determine_can_use_vulkan_sdk():
 
 
 def _determine_can_use_wgpu_lib():
-    code = "import wgpu.backend.rs;"
-    code += "wgpu.requestAdapter(powerPreference='high-performance').requestDevice()"
+    code = "import wgpu.utils; wgpu.utils.create_device()"
     try:
         subprocess.check_output(
             [sys.executable, "-c", code,]


### PR DESCRIPTION
This only changes the code that is used to determine that the wgpu can be used. The new wgpu has a function to allow testing this simpler, without using the actual wgpu API.