### PR TITLE
Remove option to use ShaderResource objects, use 3-tuples instead

### DIFF
--- a/python_shader/__init__.py
+++ b/python_shader/__init__.py
@@ -21,8 +21,7 @@ from ._types import mat2, mat3, mat4
 from ._types import Vector, Matrix, Array, Struct
 
 from ._types import shadertype_as_ctype
-from ._types import RES_INPUT, RES_OUTPUT, RES_UNIFORM, RES_BUFFER
-from ._types import InputResource, OutputResource, UniformResource
-from ._types import BufferResource, TextureResource, SamplerResource
+from ._types import RES_INPUT, RES_OUTPUT
+from ._types import RES_UNIFORM, RES_BUFFER, RES_SAMPLER, RES_TEXTURE
 
 from . import dev

--- a/python_shader/_types.py
+++ b/python_shader/_types.py
@@ -447,7 +447,6 @@ _subtypes.update(convenience_types)
 
 # %% How to expose it all
 
-
 # Types that can be referenced by name.
 gpu_types_map = {}
 gpu_types_map.update(leaf_types)
@@ -455,60 +454,11 @@ gpu_types_map.update(base_types)  # Only the last level, e,g. not ShaderType
 gpu_types_map.update(convenience_types)
 
 
-# %% IO types
-
-
-# todo: remove or revive? (was part of experimental IO syntax)
+# %% Shader resource enum
 
 RES_INPUT = "input"
 RES_OUTPUT = "output"
 RES_UNIFORM = "uniform"
 RES_BUFFER = "buffer"
-
-
-class BaseShaderResource:
-
-    kind = ""
-
-    def __init__(self, slot, subtype):
-        if not (
-            (isinstance(slot, int) and slot >= 0)
-            or (isinstance(slot, str) and len(slot) > 0)
-        ):
-            raise TypeError("IOType slot must be a nonnegative int or nonempty str.")
-        self.slot = slot
-        if not isinstance(subtype, type) and issubclass(subtype, ShaderType):
-            raise TypeError("IOType subtype must be a ShaderType.")
-        elif subtype.is_abstract:
-            raise TypeError("IOType subtype cannot be an abstract ShaderType.")
-        self.subtype = subtype
-
-
-class InputResource(BaseShaderResource):
-
-    kind = "input"
-
-
-class OutputResource(BaseShaderResource):
-
-    kind = "output"
-
-
-class UniformResource(BaseShaderResource):
-
-    kind = "uniform"
-
-
-class BufferResource(BaseShaderResource):
-
-    kind = "buffer"
-
-
-class TextureResource(BaseShaderResource):
-
-    kind = "texture"
-
-
-class SamplerResource(BaseShaderResource):
-
-    kind = "sampler"
+RES_SAMPLER = "sampler"
+RES_TEXTURE = "texture"

--- a/python_shader/py.py
+++ b/python_shader/py.py
@@ -5,7 +5,6 @@ from ._module import ShaderModule
 from .opcodes import OpCodeDefinitions as op
 from ._dis import dis
 from . import stdlib
-from . import _types
 from ._types import gpu_types_map
 
 
@@ -80,13 +79,8 @@ class PyBytecode2Bytecode:
             if argname not in py_func.__annotations__:
                 raise TypeError("Shader arguments must be annotated.")
             resource = py_func.__annotations__.get(argname, None)
-            # todo: Allow only one: either 3-tuple or Resource object
             if resource is None:
                 raise TypeError(f"Python-shader arg {argname} is not decorated.")
-            elif isinstance(resource, _types.BaseShaderResource):
-                kind = resource.kind
-                slot = resource.slot
-                subtype = resource.subtype
             elif isinstance(resource, tuple) and len(resource) == 3:
                 kind, slot, subtype = resource
                 assert isinstance(kind, str)
@@ -94,8 +88,8 @@ class PyBytecode2Bytecode:
                 assert isinstance(subtype, (type, str))
             else:
                 raise TypeError(
-                    f"Python-shader arg {argname} must be a resource object "
-                    + f"(3-tuple or e.g. InputResource), not {type(resource)}."
+                    f"Python-shader arg {argname} must be a 3-tuple, "
+                    + f"not {type(resource)}."
                 )
             kind = kind.lower()
             subtype = subtype.__name__ if isinstance(subtype, type) else subtype

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -18,8 +18,7 @@ script to get new hashes when needed:
 """
 
 import python_shader
-from python_shader import InputResource, OutputResource, BufferResource, stdlib
-from python_shader import f32, i32, vec2, vec3, vec4, ivec3, ivec4, Array
+from python_shader import stdlib, f32, i32, vec2, vec3, vec4, ivec3, ivec4, Array
 
 from pytest import mark, raises
 from testutils import can_use_vulkan_sdk, validate_module, run_test_and_print_new_hashes
@@ -34,9 +33,9 @@ def test_null_shader():
 def test_triangle_shader():
     @python2shader_and_validate
     def vertex_shader(
-        index: InputResource("VertexId", i32),
-        pos: OutputResource("Position", vec4),
-        color: OutputResource(0, vec3),
+        index: ("input", "VertexId", i32),
+        pos: ("output", "Position", vec4),
+        color: ("output", 0, vec3),
     ):
         positions = [vec2(+0.0, -0.5), vec2(+0.5, +0.5), vec2(-0.5, +0.7)]
         p = positions[index]
@@ -45,7 +44,7 @@ def test_triangle_shader():
 
     @python2shader_and_validate
     def fragment_shader(
-        in_color: InputResource(0, vec3), out_color: OutputResource(0, vec4),
+        in_color: ("input", 0, vec3), out_color: ("output", 0, vec4),
     ):
         out_color = vec4(in_color, 1.0)  # noqa
 
@@ -63,18 +62,18 @@ def test_no_duplicate_constants():
 def test_compute_shader():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(i32)),
-        data2: BufferResource(1, Array(i32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(i32)),
+        data2: ("buffer", 1, Array(i32)),
     ):
         data2[index] = data1[index]
 
 
 def test_cannot_assign_same_slot():
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(i32)),
-        data2: BufferResource(0, Array(i32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(i32)),
+        data2: ("buffer", 0, Array(i32)),
     ):
         data2[index] = data1[index]
 

--- a/tests/test_py_cast.py
+++ b/tests/test_py_cast.py
@@ -7,7 +7,6 @@ import ctypes
 
 import python_shader
 from python_shader import RES_INPUT, RES_BUFFER
-from python_shader import InputResource, BufferResource
 from python_shader import f32, f64, u8, i16, i32, i64  # noqa
 from python_shader import bvec2, ivec2, ivec3, vec2, vec3, vec4, Array  # noqa
 
@@ -43,9 +42,9 @@ def test_cast_i32_f32():
 def test_cast_u8_f32():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(u8)),
-        data2: BufferResource(1, Array(f32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(u8)),
+        data2: ("buffer", 1, Array(f32)),
     ):
         data2[index] = f32(data1[index])
 
@@ -62,9 +61,9 @@ def test_cast_u8_f32():
 def test_cast_f32_i32():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(f32)),
-        data2: BufferResource(1, Array(i32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(i32)),
     ):
         data2[index] = i32(data1[index])
 
@@ -79,9 +78,9 @@ def test_cast_f32_i32():
 def test_cast_f32_f32():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(f32)),
-        data2: BufferResource(1, Array(f32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(f32)),
     ):
         data2[index] = f32(data1[index])
 
@@ -96,9 +95,9 @@ def test_cast_f32_f32():
 def test_cast_f32_f64():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(f32)),
-        data2: BufferResource(1, Array(f64)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(f64)),
     ):
         data2[index] = f64(data1[index])
 
@@ -113,9 +112,9 @@ def test_cast_f32_f64():
 def test_cast_i64_i16():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(i64)),
-        data2: BufferResource(1, Array(i16)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(i64)),
+        data2: ("buffer", 1, Array(i16)),
     ):
         data2[index] = i16(data1[index])
 
@@ -133,9 +132,9 @@ def test_cast_i64_i16():
 def test_cast_i16_u8():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(i16)),
-        data2: BufferResource(1, Array(u8)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(i16)),
+        data2: ("buffer", 1, Array(u8)),
     ):
         data2[index] = u8(data1[index])
 
@@ -154,9 +153,9 @@ def test_cast_vec_ivec2_vec2():
     # This triggers the direct number-vector conversion
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(ivec2)),
-        data2: BufferResource(1, Array(vec2)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(ivec2)),
+        data2: ("buffer", 1, Array(vec2)),
     ):
         data2[index] = vec2(data1[index])
 
@@ -174,8 +173,7 @@ def test_cast_vec_any_vec4():
     # Look how all args in a vector are converted :)
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data2: BufferResource(1, Array(vec4)),
+        index: ("input", "GlobalInvocationId", i32), data2: ("buffer", 1, Array(vec4)),
     ):
         data2[index] = vec4(7.0, 3, ivec2(False, 2.7))
 
@@ -192,9 +190,9 @@ def test_cast_vec_any_vec4():
 def test_cast_vec_ivec3_vec3():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(ivec3)),
-        data2: BufferResource(1, Array(vec3)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(ivec3)),
+        data2: ("buffer", 1, Array(vec3)),
     ):
         data2[index] = vec3(data1[index])
 
@@ -215,9 +213,9 @@ def test_cast_ivec2_bvec2():
     # This triggers the per-element vector conversion
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(ivec2)),
-        data2: BufferResource(1, Array(ivec2)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(ivec2)),
+        data2: ("buffer", 1, Array(ivec2)),
     ):
         tmp = bvec2(data1[index])
         data2[index] = ivec2(tmp)  # ext visible storage cannot be bool

--- a/tests/test_py_compute.py
+++ b/tests/test_py_compute.py
@@ -7,7 +7,6 @@ With this we can validate arithmetic, control flow etc.
 import ctypes
 
 import python_shader
-from python_shader import InputResource, BufferResource
 from python_shader import f32, i32, ivec2, ivec3, ivec4, vec2, vec3, vec4, Array  # noqa
 
 import wgpu.backends.rs  # noqa
@@ -21,8 +20,7 @@ from testutils import validate_module, run_test_and_print_new_hashes
 def test_index():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data2: BufferResource(1, Array(i32)),
+        index: ("input", "GlobalInvocationId", i32), data2: ("buffer", 1, Array(i32)),
     ):
         data2[index] = index
 
@@ -38,9 +36,9 @@ def test_index():
 def test_copy():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(i32)),
-        data2: BufferResource(1, Array(i32)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(i32)),
+        data2: ("buffer", 1, Array(i32)),
     ):
         data2[index] = data1[index]
 
@@ -56,10 +54,10 @@ def test_copy():
 def test_copy_vec2():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(vec2)),
-        data2: BufferResource(1, Array(vec2)),
-        data3: BufferResource(2, Array(ivec2)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(vec2)),
+        data2: ("buffer", 1, Array(vec2)),
+        data3: ("buffer", 2, Array(ivec2)),
     ):
         data2[index] = data1[index].xy
         data3[index] = ivec2(index, index)
@@ -78,10 +76,10 @@ def test_copy_vec2():
 def test_copy_vec3():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(vec3)),
-        data2: BufferResource(1, Array(vec3)),
-        data3: BufferResource(2, Array(ivec3)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(vec3)),
+        data2: ("buffer", 1, Array(vec3)),
+        data3: ("buffer", 2, Array(ivec3)),
     ):
         data2[index] = data1[index].xyz
         data3[index] = ivec3(index, index, index)
@@ -127,10 +125,10 @@ def test_copy_vec3():
 def test_copy_vec4():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(vec4)),
-        data2: BufferResource(1, Array(vec4)),
-        data3: BufferResource(2, Array(ivec4)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(vec4)),
+        data2: ("buffer", 1, Array(vec4)),
+        data3: ("buffer", 2, Array(ivec4)),
     ):
         data2[index] = data1[index].xyzw
         data3[index] = ivec4(index, index, index, index)

--- a/tests/test_py_math.py
+++ b/tests/test_py_math.py
@@ -8,7 +8,6 @@ import ctypes
 
 import python_shader
 
-from python_shader import InputResource, BufferResource
 from python_shader import f32, i32, vec2, vec3, vec4, Array  # noqa
 
 import wgpu.backends.rs  # noqa
@@ -22,9 +21,9 @@ from testutils import validate_module, run_test_and_print_new_hashes
 def test_add_sub():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(f32)),
-        data2: BufferResource(1, Array(vec2)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(vec2)),
     ):
         a = data1[index]
         data2[index] = vec2(a + 1.0, a - 1.0)
@@ -45,9 +44,9 @@ def test_add_sub():
 def test_mul_div():
     @python2shader_and_validate
     def compute_shader(
-        index: InputResource("GlobalInvocationId", i32),
-        data1: BufferResource(0, Array(f32)),
-        data2: BufferResource(1, Array(vec2)),
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(vec2)),
     ):
         a = data1[index]
         data2[index] = vec2(a * 2.0, a / 2.0)


### PR DESCRIPTION
Closes #11

Also adds `RES_SAMPLER` and `RES_TEXTURE`.