### PR TITLE
Deduplicate equal texture type definitions

### DIFF
--- a/examples_py/compute.py
+++ b/examples_py/compute.py
@@ -3,7 +3,7 @@ A few compute examples. Compute shaders do not have vertex buffer inputs, nor
 outputs. Any data you need must be provided as uniform, buffer or texture.
 """
 
-from python_shader import python2shader, i32, f32, Array
+from python_shader import python2shader, i32, f32, ivec3, Array
 
 
 @python2shader
@@ -23,3 +23,18 @@ def compute_shader_multiply(
     data3: ("buffer", 2, Array(f32)),
 ):
     data3[index] = f32(data1[index]) * data2[index]
+
+
+@python2shader
+def compute_shader_tex_colorwap(
+    index: ("input", "GlobalInvocationId", ivec3),
+    tex1: ("texture", 0, "2d rgba8ui"),
+    tex2: ("texture", 1, "2d rgba8ui"),
+):
+    color = tex1.read(index.xy)
+    color = color.bgra
+    tex2.write(index.xy, color)
+
+
+# (The above shader also tests the case where we have to bound textures
+# of equal type. Which is a case that needs a bit of special handling.)

--- a/tests/test_py_examples.py
+++ b/tests/test_py_examples.py
@@ -57,6 +57,7 @@ def test(shader_name):
 HASHES = {
     "compute.compute_shader_copy": ("7b03b3564a72be3c", "46f084870ce2681b"),
     "compute.compute_shader_multiply": ("96c9e08803f51d91", "19f6fec2dca68839"),
+    "compute.compute_shader_tex_colorwap": ("782718030cb67298", "9145fedad75819cf"),
     "mesh.vertex_shader": ("588736d01ef1a3e1", "4ee757539a8e83ce"),
     "mesh.fragment_shader_flat": ("a1ee4f60c24c5693", "04ad8bd5f6cd69f1"),
     "textures.compute_shader_tex_add": ("d8fd12dbb01d1ef7", "e81ae2994c71064c"),


### PR DESCRIPTION
Explanation (technical): The texture typedef has a few fields for which the value is determined later. These values indicate how the shader is going to be used, but we don't know that until we've parsed the rest of the shader. So we use a placeholder object, and that makes that two texture typedefs can be created that are exactly equal. This PR does some de-duplication at the end.