### PR TITLE
Two nasty fixes

### DIFF
--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -366,7 +366,7 @@ class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
             )
 
         # Define slot of variable
-        if kind in ("buffer", "image", "uniform"):
+        if kind in ("buffer", "texture", "uniform"):
             assert isinstance(slot, int)
             # Default to descriptor set zero
             self.gen_instruction(

--- a/python_shader/_generator_bc.py
+++ b/python_shader/_generator_bc.py
@@ -758,7 +758,7 @@ class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
             if issubclass(arg_el_type, _types.Float):
                 self.gen_func_instruction(cc.OpFConvert, type_id, result_id, arg)
             elif issubclass(arg_el_type, _types.Int):
-                op = cc.OpConvertSToF if argtname.startswith("u") else cc.OpConvertUToF
+                op = cc.OpConvertUToF if argtname.startswith("u") else cc.OpConvertSToF
                 self.gen_func_instruction(op, type_id, result_id, arg)
             elif issubclass(arg_el_type, _types.boolean):
                 zero = self.obtain_constant(0.0, out_el_type)

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -149,10 +149,10 @@ HASHES = {
     "test_triangle_shader.vertex_shader": ("829ed988549d24fc", "53d4b596bc25b5a0"),
     "test_triangle_shader.fragment_shader": ("a617056d738350de", "6febd7dab6d72c8d"),
     "test_compute_shader.compute_shader": ("7b03b3564a72be3c", "46f084870ce2681b"),
-    "test_texture_2d_f32.fragment_shader": ("91424c7a5253087f", "d31253816d239475"),
-    "test_texture_1d_i32.fragment_shader": ("ccb700086b9676d6", "a3bb96b87afa94b2"),
-    "test_texture_3d_r16i.fragment_shader": ("4b7fd0d410a5ea46", "ef6296c81906eec4"),
-    "test_texcomp_2d_rg32i.compute_shader": ("acf2d8a9c1c111dc", "72e582d70b4fd540",),
+    "test_texture_2d_f32.fragment_shader": ("91424c7a5253087f", "6e5e9d2ef93a09be"),
+    "test_texture_1d_i32.fragment_shader": ("ccb700086b9676d6", "16925f49a7c463aa"),
+    "test_texture_3d_r16i.fragment_shader": ("4b7fd0d410a5ea46", "5bd384f1742c16bc"),
+    "test_texcomp_2d_rg32i.compute_shader": ("acf2d8a9c1c111dc", "609468500982bfbd"),
 }
 
 

--- a/tests/test_py_compute.py
+++ b/tests/test_py_compute.py
@@ -111,15 +111,20 @@ def test_copy_vec3():
     assert iters_equal(out[1][0::4], range(0, 60, 4))
     assert iters_equal(out[1][1::4], range(1, 60, 4))
     assert iters_equal(out[1][2::4], range(2, 60, 4))
-    assert iters_equal(out[1][3::4], [0 for i in range(3, 60, 4)])
+    # Depending on your driver, this might or might not work
+    align_ok = iters_equal(out[1][3::4], range(3, 60, 4))
+    align_fail = iters_equal(out[1][3::4], [0 for i in range(3, 60, 4)])
+    assert align_ok or align_fail
 
-    # assert iters_equal(out[2][0::3], range(20))
-    # assert iters_equal(out[2][1::3], range(20))
-    # assert iters_equal(out[2][2::3], range(20))
-    assert iters_equal(out[2][0::4], range(15))
-    assert iters_equal(out[2][1::4], range(15))
-    assert iters_equal(out[2][2::4], range(15))
-    assert iters_equal(out[2][3::4], [0 for i in range(15)])
+    if align_ok:
+        assert iters_equal(out[2][0::3], range(20))
+        assert iters_equal(out[2][1::3], range(20))
+        assert iters_equal(out[2][2::3], range(20))
+    if align_fail:
+        assert iters_equal(out[2][0::4], range(15))
+        assert iters_equal(out[2][1::4], range(15))
+        assert iters_equal(out[2][2::4], range(15))
+        assert iters_equal(out[2][3::4], [0 for i in range(15)])
 
 
 def test_copy_vec4():

--- a/tests/test_py_examples.py
+++ b/tests/test_py_examples.py
@@ -56,12 +56,12 @@ def test(shader_name):
 
 HASHES = {
     "compute.compute_shader_copy": ("7b03b3564a72be3c", "46f084870ce2681b"),
-    "compute.compute_shader_multiply": ("96c9e08803f51d91", "19f6fec2dca68839"),
-    "compute.compute_shader_tex_colorwap": ("782718030cb67298", "9145fedad75819cf"),
+    "compute.compute_shader_multiply": ("96c9e08803f51d91", "8f197b15205b5a51"),
+    "compute.compute_shader_tex_colorwap": ("782718030cb67298", "46604895ec75f8a3"),
     "mesh.vertex_shader": ("588736d01ef1a3e1", "4ee757539a8e83ce"),
     "mesh.fragment_shader_flat": ("a1ee4f60c24c5693", "04ad8bd5f6cd69f1"),
-    "textures.compute_shader_tex_add": ("d8fd12dbb01d1ef7", "e81ae2994c71064c"),
-    "textures.fragment_shader_tex": ("927569ad5a038680", "e4d9b4ebfda9f897"),
+    "textures.compute_shader_tex_add": ("d8fd12dbb01d1ef7", "03d5f2079a960a24"),
+    "textures.fragment_shader_tex": ("927569ad5a038680", "7e457d5c780d5b38"),
     "triangle.vertex_shader": ("535c85e75318f7e9", "53d4b596bc25b5a0"),
     "triangle.fragment_shader": ("c54813968ded4543", "6febd7dab6d72c8d"),
 }

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -11,8 +11,10 @@ def iters_equal(iter1, iter2):
     """ Assert that the given iterators are equal.
     """
     iter1, iter2 = list(iter1), list(iter2)
-    assert len(iter1) == len(iter2)
-    assert all(iter1[i] == iter2[i] for i in range(len(iter1)))
+    if len(iter1) != len(iter2):
+        return False
+    if not all(iter1[i] == iter2[i] for i in range(len(iter1))):
+        return False
     return True
 
 


### PR DESCRIPTION
I updated my drivers, and now many things stopped working :)  But really, it reveals some bugs.

* Forgot to change "image" to "texture" somewhere. This caused that the resulting SpirV did not have a DescriptorSet decoration for textures. Somehow this was fine for some cases, but it did cause the wgpu `test_rs_compute_tex.py` to segfault.
* In the float to int conversion, I had uint and int reversed. Woops. Not sure why it worked before.
* The alignment issues with storage buffers are now gone, so needed to update some tests for that.